### PR TITLE
Remove ephemeral property from confirmation

### DIFF
--- a/src/commands/info/submit.py
+++ b/src/commands/info/submit.py
@@ -30,7 +30,7 @@ class Submit(commands.Cog):
 
         # AllowedMentions(users=False) allows us to mention the user but not ping them
         await ctx.bot.get_channel(SUBMISSIONS_CHANNEL).send(submission_message, allowed_mentions=AllowedMentions(users=False))
-        await ctx.respond(response_message, ephemeral=True)
+        await ctx.respond(response_message)
 
 
 def setup(bot):


### PR DESCRIPTION
People didn't like not seeing the submissions in the channel they were posted from.